### PR TITLE
Make d3-support compatible with pre-1.13.9 versions of Ember

### DIFF
--- a/addon/mixins/d3-support.js
+++ b/addon/mixins/d3-support.js
@@ -14,6 +14,7 @@ const GraphicSupport = Ember.Mixin.create({
   call() {},
 
   didReceiveAttrs() {
+    this._super(...arguments);
     var selection = this.get('select');
 
     if (selection && !this.isDestroying && this.get('requiredProperties').map(prop => Boolean(!!this.get(prop))).reduce(((prev, cur) => prev && cur), true)) {


### PR DESCRIPTION
Due to https://github.com/emberjs/ember.js/pull/12138 the library doesn't currently support older versions of ember
